### PR TITLE
upgrade to work with GHC-7.8

### DIFF
--- a/lambdacube-core/LC_B_GLData.hs
+++ b/lambdacube-core/LC_B_GLData.hs
@@ -8,6 +8,7 @@ import Data.List as L
 import Data.Maybe
 import Data.Trie as T
 import Foreign 
+import System.IO.Unsafe
 --import qualified Data.IntMap as IM
 import qualified Data.Map as Map
 import qualified Data.Set as Set

--- a/lambdacube-core/LC_C_Convert.hs
+++ b/lambdacube-core/LC_C_Convert.hs
@@ -16,8 +16,8 @@ import LC_G_APIType
 import LC_C_PrimFun
 import LC_G_Type as G
 
-toInt :: SingI n => T.NatNum n -> Int
-toInt (a :: T.NatNum n) = fromInteger $ fromSing (sing :: Sing (n :: Nat))
+toInt :: KnownNat n => T.NatNum n -> Int
+toInt (a :: T.NatNum n) = fromInteger $ natVal a
 
 prjIdx i lyt = i--length lyt - i - 1
 

--- a/lambdacube-core/LC_T_APIType.hs
+++ b/lambdacube-core/LC_T_APIType.hs
@@ -275,17 +275,17 @@ data FragmentOperation ty where
 -- specifies an empty image (pixel rectangle)
 -- hint: framebuffer is composed from images
 data Image (layerCount :: Nat) t where
-    DepthImage      :: SingI layerCount
+    DepthImage      :: KnownNat layerCount
                     => NatNum layerCount
                     -> Float    -- initial value
                     -> Image layerCount (Depth Float)
 
-    StencilImage    :: SingI layerCount
+    StencilImage    :: KnownNat layerCount
                     => NatNum layerCount
                     -> Int32    -- initial value
                     -> Image layerCount (Stencil Int32)
 
-    ColorImage      :: (IsNum t, IsVecScalar d color t, IsScalar color, SingI layerCount)
+    ColorImage      :: (IsNum t, IsVecScalar d color t, IsScalar color, KnownNat layerCount)
                     => NatNum layerCount
                     -> color    -- initial value
                     -> Image layerCount (Color color)
@@ -420,12 +420,12 @@ instance IsColorArity RGBA where
 
 -- fully describes a texture type
 data TextureType :: TextureShape -> TextureMipMap -> TextureArray -> Nat -> TextureSemantics * -> * -> * where -- hint: arr - single or array texture, ar - arity (Red,RG,RGB,..)
-    Texture1D       :: SingI layerCount
+    Texture1D       :: KnownNat layerCount
                     => TextureDataType t ar
                     -> NatNum layerCount
                     -> TextureType Tex1D TexMip (TexArrRepr layerCount) layerCount t ar
 
-    Texture2D       :: SingI layerCount
+    Texture2D       :: KnownNat layerCount
                     => TextureDataType t ar
                     -> NatNum layerCount
                     -> TextureType Tex2D TexMip (TexArrRepr layerCount) layerCount t ar
@@ -439,7 +439,7 @@ data TextureType :: TextureShape -> TextureMipMap -> TextureArray -> Nat -> Text
     TextureRect     :: TextureDataType t ar
                     -> TextureType TexRect TexNoMip SingleTex 1 t ar
 
-    Texture2DMS     :: SingI layerCount
+    Texture2DMS     :: KnownNat layerCount
                     => TextureDataType (Regular t) ar
                     -> NatNum layerCount
                     -> TextureType Tex2D TexNoMip (TexArrRepr layerCount) layerCount (MultiSample t) ar

--- a/lambdacube-core/LC_T_HOAS.hs
+++ b/lambdacube-core/LC_T_HOAS.hs
@@ -118,7 +118,7 @@ data Exp :: Frequency -> * -> * where
                     -> Exp Obj (FrameBuffer layerCount b)
                     -> Exp Obj (Image layerCount t)
 
-    PrjImage        :: ((idx + 1) <= layerCount, 2 <= layerCount, SingI idx)
+    PrjImage        :: ((idx + 1) <= layerCount, 2 <= layerCount, KnownNat idx)
                     => ByteString                       -- internal image output (can be allocated on request)
                     -> NatNum idx
                     -> Exp Obj (Image layerCount t)
@@ -155,7 +155,7 @@ data VertexOut clipDistances t where
 -- Geometry
 -- describes a geometry shader
 data GeometryShader (inPrimitive :: PrimitiveType) (outPrimitive :: PrimitiveType) inClipDistances outClipDistances (layerCount :: Nat) a b where
-    GeometryShader  :: (GPU j, GPU i, GPU b, GPU outputClipDistances, GPU input, SingI layerCount
+    GeometryShader  :: (GPU j, GPU i, GPU b, GPU outputClipDistances, GPU input, KnownNat layerCount
                        , inputVertex ~ (V4F,Float,inputClipDistances,a)
                        , input ~ PrimitiveVertices inputPrimitive inputVertex
                        )
@@ -168,7 +168,7 @@ data GeometryShader (inPrimitive :: PrimitiveType) (outPrimitive :: PrimitiveTyp
                     -> (Exp G j -> GeometryOut j outputClipDistances b)             -- generate vertices
                     -> GeometryShader inputPrimitive outputPrimitive inputClipDistances outputClipDistances layerCount a b
 {-
-    GeometryShader      :: (GPU (PrimitiveVertices primIn a), GPU i, GPU j, GPU b, IsPrimitive primIn, IsPrimitive primOut, SingI layerNum)
+    GeometryShader      :: (GPU (PrimitiveVertices primIn a), GPU i, GPU j, GPU b, IsPrimitive primIn, IsPrimitive primOut, KnownNat layerNum)
                         => NatNum layerNum                                          -- geometry shader:
                         -> primOut                                                  -- output primitive
                         -> Int                                                      -- max amount of generated vertices

--- a/lambdacube-core/lambdacube-core.cabal
+++ b/lambdacube-core/lambdacube-core.cabal
@@ -28,7 +28,7 @@ Description:
 
 Library
   Build-Depends:
-        base >=4.6 && <4.7, containers >=0.5 && <0.6, mtl >=2.1 && <2.2, bytestring >=0.10 && <0.11, bytestring-trie >=0.2 && <0.3, vector >=0.10 && <0.11, OpenGLRaw >=1.4 && <1.5, bitmap >=0.0 && <0.1, prettyclass >=1.0 && <1.1, language-glsl >=0.0 && <0.1, binary >=0.7 && <0.8
+        base >=4.6, containers >=0.5 && <0.6, mtl >=2.1 && <2.2, bytestring >=0.10 && <0.11, bytestring-trie >=0.2 && <0.3, vector >=0.10 && <0.11, OpenGLRaw >=1.4 && <1.5, bitmap >=0.0 && <0.1, prettyclass >=1.0 && <1.1, language-glsl >=0.0 && <0.1, binary >=0.7 && <0.8, ghc-prim
   Exposed-modules:
         BiMap
         LC_API

--- a/lambdacube-samples/lambdacube-samples.cabal
+++ b/lambdacube-samples/lambdacube-samples.cabal
@@ -46,28 +46,28 @@ executable lambdacube-hello
   main-is:             Hello.hs
   -- other-modules:
   other-extensions:    OverloadedStrings, TypeOperators, NoMonomorphismRestriction, ExistentialQuantification, PackageImports, DoRec, ParallelListComp, DataKinds, NamedFieldPuns
-  build-depends:       base >=4.6 && <4.7, mtl >=2.1 && <2.2, bytestring >=0.10 && <0.11, bytestring-trie >=0.2 && <0.3, vect >=0.4 && <0.5, vector >=0.10 && <0.11, elerea >=2.7 && <2.8, lambdacube-core >=0.1 && <0.2, time >=1.4 && <1.5, OpenGLRaw >=1.4 && <1.5, GLFW-b ==0.1.0.5, stb-image ==0.2.1
+  build-depends:       base >=4.6, mtl >=2.1 && <2.2, bytestring >=0.10 && <0.11, bytestring-trie >=0.2 && <0.3, vect >=0.4 && <0.5, vector >=0.10 && <0.11, elerea >=2.7 && <2.8, lambdacube-core >=0.1 && <0.2, time >=1.4 && <1.5, OpenGLRaw >=1.4 && <1.5, GLFW-b ==0.1.0.5, stb-image ==0.2.1
   default-language:    Haskell2010
 
 executable lambdacube-shadowmapping
   main-is:             ShadowMapping.hs
   -- other-modules:
   other-extensions:    OverloadedStrings, TypeOperators, NoMonomorphismRestriction, ExistentialQuantification, PackageImports, DoRec, ParallelListComp, DataKinds, NamedFieldPuns
-  build-depends:       base >=4.6 && <4.7, mtl >=2.1 && <2.2, bytestring >=0.10 && <0.11, bytestring-trie >=0.2 && <0.3, vect >=0.4 && <0.5, vector >=0.10 && <0.11, elerea >=2.7 && <2.8, lambdacube-core >=0.1 && <0.2, time >=1.4 && <1.5, OpenGLRaw >=1.4 && <1.5, GLFW-b ==0.1.0.5
+  build-depends:       base >=4.6, mtl >=2.1 && <2.2, bytestring >=0.10 && <0.11, bytestring-trie >=0.2 && <0.3, vect >=0.4 && <0.5, vector >=0.10 && <0.11, elerea >=2.7 && <2.8, lambdacube-core >=0.1 && <0.2, time >=1.4 && <1.5, OpenGLRaw >=1.4 && <1.5, GLFW-b ==0.1.0.5
   default-language:    Haskell2010
 
 executable lambdacube-cubemap
   main-is:             CubeMap.hs
   -- other-modules:
   other-extensions:    OverloadedStrings, TypeOperators, NoMonomorphismRestriction, ExistentialQuantification, PackageImports, DoRec, ParallelListComp, DataKinds, NamedFieldPuns
-  build-depends:       base >=4.6 && <4.7, mtl >=2.1 && <2.2, bytestring >=0.10 && <0.11, bytestring-trie >=0.2 && <0.3, vect >=0.4 && <0.5, vector >=0.10 && <0.11, elerea >=2.7 && <2.8, lambdacube-core >=0.1 && <0.2, time >=1.4 && <1.5, OpenGLRaw >=1.4 && <1.5, GLFW-b ==0.1.0.5
+  build-depends:       base >=4.6, mtl >=2.1 && <2.2, bytestring >=0.10 && <0.11, bytestring-trie >=0.2 && <0.3, vect >=0.4 && <0.5, vector >=0.10 && <0.11, elerea >=2.7 && <2.8, lambdacube-core >=0.1 && <0.2, time >=1.4 && <1.5, OpenGLRaw >=1.4 && <1.5, GLFW-b ==0.1.0.5
   default-language:    Haskell2010
 
 executable lambdacube-convolutionfilter
   main-is:             ConvolutionFilter.hs
   -- other-modules:
   other-extensions:    OverloadedStrings, TypeOperators, NoMonomorphismRestriction, ExistentialQuantification, PackageImports, DoRec, ParallelListComp, DataKinds, NamedFieldPuns
-  build-depends:       base >=4.6 && <4.7, mtl >=2.1 && <2.2, bytestring >=0.10 && <0.11, bytestring-trie >=0.2 && <0.3, vect >=0.4 && <0.5, vector >=0.10 && <0.11, elerea >=2.7 && <2.8, lambdacube-core >=0.1 && <0.2, time >=1.4 && <1.5, OpenGLRaw >=1.4 && <1.5, GLFW-b ==0.1.0.5
+  build-depends:       base >=4.6, mtl >=2.1 && <2.2, bytestring >=0.10 && <0.11, bytestring-trie >=0.2 && <0.3, vect >=0.4 && <0.5, vector >=0.10 && <0.11, elerea >=2.7 && <2.8, lambdacube-core >=0.1 && <0.2, time >=1.4 && <1.5, OpenGLRaw >=1.4 && <1.5, GLFW-b ==0.1.0.5
   default-language:    Haskell2010
 
 executable lambdacube-bulletexample
@@ -75,7 +75,7 @@ executable lambdacube-bulletexample
   -- other-modules:
   other-extensions:    OverloadedStrings, TypeOperators, NoMonomorphismRestriction, ExistentialQuantification, PackageImports, DoRec, ParallelListComp, DataKinds, NamedFieldPuns
   if flag(BulletInstalled)
-    build-depends:       base >=4.6 && <4.7, mtl >=2.1 && <2.2, bytestring >=0.10 && <0.11, bytestring-trie >=0.2 && <0.3, vect >=0.4 && <0.5, vector >=0.10 && <0.11, elerea >=2.7 && <2.8, bullet >=0.2 && <0.3, lambdacube-core >=0.1 && <0.2, time >=1.4 && <1.5, OpenGLRaw >=1.4 && <1.5, GLFW-b ==0.1.0.5
+    build-depends:       base >=4.6, mtl >=2.1 && <2.2, bytestring >=0.10 && <0.11, bytestring-trie >=0.2 && <0.3, vect >=0.4 && <0.5, vector >=0.10 && <0.11, elerea >=2.7 && <2.8, bullet >=0.2 && <0.3, lambdacube-core >=0.1 && <0.2, time >=1.4 && <1.5, OpenGLRaw >=1.4 && <1.5, GLFW-b ==0.1.0.5
   else
     buildable: False
   default-language:    Haskell2010


### PR DESCRIPTION
Fix so that it works with GHC-7.8.
Changes:
- GHC.TypeLits has changed quite a bit (SingI no longer exists)
- unsafePerformIO has been moved to System.IO.Unsafe

Note that I'm not entirely sure of the fix in LC_C_Convert but it seems to work.
